### PR TITLE
Add CI badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 # kube-named-ports
+
+[![Build Status](https://travis-ci.org/bpineau/kube-named-ports.svg?branch=master)](https://travis-ci.org/bpineau/kube-named-ports)
+[![Coverage Status](https://coveralls.io/repos/github/bpineau/kube-named-ports/badge.svg?branch=master)](https://coveralls.io/github/bpineau/kube-named-ports?branch=master)
+[![Go Report Card](https://goreportcard.com/badge/github.com/bpineau/kube-named-ports)](https://goreportcard.com/report/github.com/bpineau/kube-named-ports)
+
 Declare GCP named ports on GKE node pools's instance groups according to Kubernetes services annotations.
 
 ## Annotations


### PR DESCRIPTION
Even though we still have to write most of the unit tests,
having Travis CI to ensure each PR builds correctly (and
pass static analysis, linters, etc) is already useful.