### PR TITLE
Publish docker images on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,12 @@
 name: CI
-on: [push, pull_request]
+on:
+  # don't double build on PRs.
+  pull_request:
+  push:
+    branches:
+    - master
+    tags-ignore:
+      - '**'
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v1
 
     - name: Log into Docker registry
-      run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+      run: echo "${{ secrets.DOCKER_TOKEN }}" | docker login -u ${{ github.actor }} --password-stdin
 
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v1


### PR DESCRIPTION
2nd try, this time using a Docker Hub token.

While at it: don't double build for no reasons; only trigger the CI
github action on (non tag) push events to master, or PRs.