### PR TITLE
fix: manage deleted objects

### DIFF
--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -184,10 +184,14 @@ func (c *Controller) processNextItem() bool {
 }
 
 func (c *Controller) processItem(key string) error {
-	obj, _, err := c.informer.GetIndexer().GetByKey(key)
+	obj, exist, err := c.informer.GetIndexer().GetByKey(key)
 
 	if err != nil {
 		return fmt.Errorf("Error fetching object with key %s from store: %v", key, err)
+	}
+
+	if !exist {
+		return fmt.Errorf("Object doesn't exist anymore with key %s", key)
 	}
 
 	svc := obj.(*core_v1.Service)


### PR DESCRIPTION
when resources are deleted, processItem() exit in panic:
```
E0111 06:44:40.102798       1 runtime.go:73] Observed a panic: &runtime.TypeAssertionError{_interface:(*runtime._type)(0x16f96a0), concrete:(*runtime._type)(nil), asserted:(*runtime._type)(0x19837c0), missingMethod:""} (interface conversion: interface {} is nil, not *v1.Service)
goroutine 21 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic(0x1751d20, 0xc00026b230)
	/home/runner/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20190817020851-f2f3a405f61d/pkg/util/runtime/runtime.go:69 +0x7b
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/home/runner/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20190817020851-f2f3a405f61d/pkg/util/runtime/runtime.go:51 +0x82
panic(0x1751d20, 0xc00026b230)
	/opt/hostedtoolcache/go/1.13.4/x64/src/runtime/panic.go:679 +0x1b2
github.com/bpineau/kube-named-ports/pkg/services.(*Controller).processItem(0xc0000f5030, 0xc0005ec210, 0x24, 0x0, 0x0)
	/home/runner/work/kube-named-ports/kube-named-ports/pkg/services/services.go:193 +0x584
```

`GetByKey()` allows us to check for existence, so let's use it !